### PR TITLE
Use global parseInt instead of Number.parseInt

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -34,8 +34,8 @@ if(argv.version) {
         configPath = path.resolve(argv.config);
         run(configPath, {
             watch: argv.watch,
-            maxRetries: Number.parseInt(argv['max-retries'], 10),
-            maxConcurrentWorkers: Number.parseInt(argv['parallel'], 10),
+            maxRetries: parseInt(argv['max-retries'], 10),
+            maxConcurrentWorkers: parseInt(argv['parallel'], 10),
             bail: argv.bail,
             json: argv.json,
             modulesSort: argv['sort-modules-by'],

--- a/index.js
+++ b/index.js
@@ -120,9 +120,9 @@ function run(configPath, options, callback) {
         };
     }
 
-    var maxRetries = options && Number.parseInt(options.maxRetries, 10) || Infinity,
+    var maxRetries = options && parseInt(options.maxRetries, 10) || Infinity,
         maxConcurrentWorkers = options
-            && Number.parseInt(options.maxConcurrentWorkers, 10)
+            && parseInt(options.maxConcurrentWorkers, 10)
             || require('os').cpus().length,
         workers = workerFarm({
             maxRetries: maxRetries,


### PR DESCRIPTION
`Number.parseInt` does not seem to be available on node v0.10.