### PR TITLE
various fixes for programmatic output (mostly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ var run = require('parallel-webpack').run,
 run(configPath, {
     watch: false,
     maxRetries: 1,
+    stats: true, // defaults to false
     maxConcurrentWorkers: 2 // use 2 workers
 });
 ```

--- a/bin/run.js
+++ b/bin/run.js
@@ -52,14 +52,7 @@ if(argv.version) {
                 }), null, 2) + "\n");
             }
         }).catch(function(err) {
-            if(err.message) {
-                process.stdout.write(err.message + "\n");
-                if(err.error) {
-                    console.error(err.error);
-                }
-            } else {
-                console.error(err);
-            }
+            console.log(err.message);
             process.exit(1);
         });
     } catch (e) {

--- a/index.js
+++ b/index.js
@@ -1,30 +1,18 @@
 var workerFarm = require('worker-farm'),
     Promise = require('bluebird'),
     chalk = require('chalk'),
-    _ = require('lodash');
+    pluralize = require('pluralize');
 
-function isSilent(options) {
-    return options && !options.json;
+function notSilent(options) {
+    return !options.json;
 }
 
-function startSingleConfigWorker(configPath, options, runWorker) {
-    if(isSilent(options)) {
-        process.stdout.write(chalk.blue('[WEBPACK]') + ' Building ' + chalk.yellow('1') + ' configuration' + "\n");
-    }
-    var worker = require('./src/webpackWorker');
-    return new Promise(function(resolve, reject) {
-        worker(configPath, options, 0, 1, function(err, stats) {
-            if(err) {
-                return reject(err);
-            }
-            resolve([stats]);
-        });
-    });
-}
+function startFarm(config, configPath, options, runWorker) {
+    config = Array.isArray(config) ? config : [config];
+    options = options || {};
 
-function startMultiConfigFarm(config, configPath, options, runWorker) {
-    if(isSilent(options)) {
-        process.stdout.write(chalk.blue('[WEBPACK]') + ' Building ' + chalk.yellow(config.length) + ' targets in parallel' + "\n");
+    if(notSilent(options)) {
+        console.log(chalk.blue('[WEBPACK]') + ' Building ' + chalk.yellow(config.length) + ' ' + pluralize('target', config.length));
     }
     var builds = config.map(function (c, i) {
         return runWorker(configPath, options, i, config.length);
@@ -32,62 +20,13 @@ function startMultiConfigFarm(config, configPath, options, runWorker) {
     if(options.bail) {
         return Promise.all(builds);
     } else {
-        return Promise.all(builds.map(function(build) {
-            return build.reflect();
-        })).then(function(results) {
-            return Promise.all(results.map(function(buildInspection) {
-                if(buildInspection.isFulfilled) {
-                    return buildInspection.value();
-                } else {
-                    return Promise.reject(buildInspection.reason());
+        return Promise.settle(builds).then(function(results) {
+            return Promise.all(results.map(function (result) {
+                if(result.isFulfilled()) {
+                    return result.value();
                 }
+                return Promise.reject(result.reason());
             }));
-        });
-    }
-}
-
-function startFarm(config, configPath, options, runWorker) {
-    // special handling for cases where only one config is exported as array
-    // unpack and treat as single config
-    if(_.isArray(config) && config.length === 1) {
-        config = config[0];
-    }
-    if(!_.isArray(config)) {
-        return startSingleConfigWorker(configPath, options, runWorker);
-    } else {
-        return startMultiConfigFarm(config, configPath, options, runWorker);
-    }
-}
-
-function closeFarm(workers, options, done, startTime) {
-    return function(err, stats) {
-        workerFarm.end(workers);
-        if(isSilent(options)) {
-            if(err) {
-                console.log('%s Build failed after %s seconds', chalk.red('[WEBPACK]'), chalk.blue((new Date().getTime() - startTime) / 1000));
-            } else {
-                console.log('%s Finished build after %s seconds', chalk.blue('[WEBPACK]'), chalk.blue((new Date().getTime() - startTime) / 1000));
-            }
-        }
-        if (done) {
-            done(err, stats);
-        }
-        if(err) {
-            throw err;
-        }
-        return stats;
-    }
-}
-
-function promisify(workers) {
-    return function(configPath, options, i, configLength) {
-        return new Promise(function(resolve, reject) {
-            workers(configPath, options, i, configLength, function(err, res) {
-                if(err) {
-                    return reject(err);
-                }
-                resolve(res);
-            });
         });
     }
 }
@@ -96,55 +35,76 @@ function promisify(workers) {
  * Runs the specified webpack configuration in parallel.
  * @param {String} configPath The path to the webpack.config.js
  * @param {Object} options
- * @param {Boolean} [options.watch=false] If `true`, Webpack will run in `watch-mode`.
- * @param {boolean} [options.maxRetries=Infinity] The maximum amount of retries on build error
- * @param {Number} [options.maxConcurrentWorkers=require('os').cpus().length] The maximum number of parallel workers
- * @param {Function} [callback] A callback to be invoked once the build has been completed
- * @return {Promise} A Promise that is resolved once all builds have been created
+ * @param {Boolean} [options.watch=false] If `true`, Webpack will run in
+ *   `watch-mode`.
+ * @param {boolean} [options.maxRetries=Infinity] The maximum amount of retries
+ *   on build error
+ * @param {Number} [options.maxConcurrentWorkers=require('os').cpus().length] The
+ *   maximum number of parallel workers
+ * @param {Function} [callback] A callback to be invoked once the build has
+ *   been completed
+ * @return {Promise} A Promise that is resolved once all builds have been
+ *   created
  */
 function run(configPath, options, callback) {
     var config,
         argvBackup = process.argv;
+    options = options || {};
+    if(options.colors === undefined) {
+        options.colors = chalk.supportsColor;
+    }
     if(!options.argv) {
         options.argv = [];
     }
-    options.argv = ['node', 'parallel-webpack'].concat(options.argv);
+    options.argv = options.argv.unshift(process.execPath, 'parallel-webpack');
     try {
         process.argv = options.argv;
         config = require(configPath);
         process.argv = argvBackup;
     } catch(e) {
-        throw {
-            message: chalk.red('[WEBPACK]') + ' Could not load configuration file ' + chalk.underline(configPath),
-            error: e
-        };
+        process.argv = argvBackup;
+        return Promise.reject(new Error(chalk.red('[WEBPACK]') + ' Could not load configuration file ' + chalk.underline(configPath)));
     }
 
-    var maxRetries = options && parseInt(options.maxRetries, 10) || Infinity,
-        maxConcurrentWorkers = options
-            && parseInt(options.maxConcurrentWorkers, 10)
+    var maxRetries = parseInt(options.maxRetries, 10) || 0,
+        maxConcurrentWorkers = parseInt(options.maxConcurrentWorkers, 10)
             || require('os').cpus().length,
         workers = workerFarm({
             maxRetries: maxRetries,
             maxConcurrentWorkers: maxConcurrentWorkers
-        }, require.resolve('./src/webpackWorker')),
-        done = closeFarm(workers, options, callback, +new Date());
+        }, require.resolve('./src/webpackWorker'));
 
     process.on('SIGINT', function() {
-        console.log(chalk.red('[WEBPACK]') + ' Forcefully shutting down');
-        done();
+        if (notSilent(options)) {
+            console.log(chalk.red('[WEBPACK]') + ' Forcefully shutting down');
+        }
+        workerFarm.end(workers);
     });
 
+    var startTime = Date.now();
     return startFarm(
         config,
         configPath,
-        options || {},
-        promisify(workers)
-    ).then(function(err, res) {
-        return done(null, res);
-    }, function(err) {
-        throw done(err);
-    });
+        options,
+        Promise.promisify(workers)
+    ).error(function(err) {
+        if(notSilent(options)) {
+            console.log('%s Build failed after %s seconds', chalk.red('[WEBPACK]'), chalk.blue((Date.now() - startTime) / 1000));
+        }
+        return Promise.reject(err);
+    }).then(function (results) {
+        if(notSilent(options)) {
+            console.log('%s Finished build after %s seconds', chalk.blue('[WEBPACK]'), chalk.blue((Date.now() - startTime) / 1000));
+        }
+        results = results.filter(function(result) {
+            return result;
+        });
+        if(results.length) {
+            return results;
+        }
+    }).finally(function () {
+        workerFarm.end(workers);
+    }).asCallback(callback);
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "dependencies": {
     "bluebird": "^3.0.6",
     "chalk": "^1.1.1",
-    "lodash": "^3.10.1",
     "minimist": "^1.2.0",
+    "pluralize": "^1.2.1",
     "supports-color": "^3.1.2",
     "webpack": "^1.12.9",
     "worker-farm": "^1.3.1"

--- a/src/createVariants.js
+++ b/src/createVariants.js
@@ -1,7 +1,6 @@
 /**
  * Created by pgotthardt on 07/12/15.
  */
-var _ = require('lodash');
 
 /**
  * Creates configuration variants.
@@ -15,7 +14,7 @@ var _ = require('lodash');
 module.exports = function createVariants(baseConfig, variants, configCallback) {
     if(arguments.length < 3) {
         if(arguments.length === 2) {
-            if(_.isFunction(variants)) {
+            if(typeof variants === 'function') {
                 // createVariants(variants: Object, configCallback: Function)
                 configCallback = variants;
                 variants = baseConfig;

--- a/src/webpackWorker.js
+++ b/src/webpackWorker.js
@@ -50,7 +50,8 @@ function getOutputOptions(webpackConfig, options) {
  * @param {Object} options The build options
  * @param {boolean} options.watch If `true`, then the webpack watcher is being run; if `false`, runs only ones
  * @param {boolean} options.json If `true`, then the webpack watcher will only report the result as JSON but not produce any other output
- * @param {Number} index The configuration index
+ * @param {number} index The configuration index
+ * @param {number} expectedConfigLength
  * @param {Function} done The callback that should be invoked once this worker has finished the build.
  */
 module.exports = function(configuratorFileName, options, index, expectedConfigLength, done) {


### PR DESCRIPTION
- simplify error reporting in CLI
- fix jsdoc in `webpackWorker.js`
- remove `lodash` dependency
- simplified starting a worker farm
- tried to normalize use of `console.log()` over `process.stdout.write`
- simplify various bits with Bluebird API
- output color in workers if supported, by default
- normalized mixture of Promises and callbacks (use Promises, support callbacks in programmatic API)
- resolved value from programmatic API only present if anything output
- add `pluralize` dependency
- add note about `stats` option in `README.md`

You'll want to test this yourself, obviously, because there aren't any tests and I don't know your use case(s).