### PR TITLE
Moved webpack to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "bugs": {
     "url": "https://github.com/trivago/parallel-webpack/issues"
   },
+  "peerDependencies": {
+    "webpack": "^1.12.9 || ^2.2.0"
+  },
   "dependencies": {
     "ajv": "^4.9.2",
     "bluebird": "^3.0.6",
@@ -33,7 +36,6 @@
     "minimist": "^1.2.0",
     "pluralize": "^1.2.1",
     "supports-color": "^3.1.2",
-    "webpack": "^1.12.9 || ^2.2.0",
     "worker-farm": "^1.3.1"
   }
 }


### PR DESCRIPTION
This avoids problems with having 2 webpacks if the consumer project also depends on webpack for other things.