### PR TITLE
Pass watch options to the compiler

### DIFF
--- a/src/webpackWorker.js
+++ b/src/webpackWorker.js
@@ -139,7 +139,7 @@ module.exports = function(configuratorFileName, options, index, expectedConfigLe
         }
         var compiler = webpack(webpackConfig);
         if(watch || webpack.watch) {
-            watcher = compiler.watch({}, finishedCallback);
+            watcher = compiler.watch(webpackConfig.watchOptions, finishedCallback);
         } else {
             compiler.run(finishedCallback);
         }


### PR DESCRIPTION
Right now, the [watch options](https://webpack.js.org/configuration/watch/#watchoptions) are ignored when using parallel-webpack. Let's fix this.