### PR TITLE
Adjust basic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,17 @@ so that we have full control over its versions.
 Given a `webpack.config.js` like this:
 
 ```javascript
+var path = require('path');
 module.exports = [{
-    entry: 'pageA.js',
+    entry: './pageA.js',
     output: {
-        path: './dist',
+        path: path.resolve(__dirname, './dist'),
         filename: 'pageA.bundle.js'
     }
 }, {
-    entry: 'pageB.js',
+    entry: './pageB.js',
     output: {
-        path: './dist',
+        path: path.resolve(__dirname, './dist'),
         filename: 'pageB.bundle.js'
     }
 }];


### PR DESCRIPTION
apparently starting with 2.3 of webpack, relative paths for the output are not allowed anymore (package.json looks like 3.0 is supported so…)
`configuration.output.path: The provided value "./dist" is not an absolute path!`
also the entry points require the relative path prefix, otherwise the files are not found
`Entry module not found: Error: Can't resolve 'pageB.js' in '/home/rschuh/projects/parallel-webpack-test'`