### PR TITLE
support config as export function v2

### DIFF
--- a/src/loadConfigurationFile.js
+++ b/src/loadConfigurationFile.js
@@ -30,6 +30,16 @@ function getMatchingLoader(configPath) {
     return null;
 }
 
+function callConfigFunction(fn) {
+    return fn(require('minimist')(process.argv, { '--': true }).env || {});
+}
+
+function getConfig(configPath) {
+    var configModule = require(configPath);
+    var configDefault = configModule && configModule.__esModule ? configModule.default : configModule;
+    return typeof configDefault === 'function' ? callConfigFunction(configDefault) : configDefault;
+}
+
 module.exports = function(configPath) {
     var mod = getMatchingLoader(configPath);
     if(mod) {
@@ -60,12 +70,5 @@ module.exports = function(configPath) {
             throw new Error('Could not load required module loading for ' + chalk.underline(configPath));
         }
     }
-    var config = require(configPath);
-    if (typeof config === 'function')
-        return config(require('minimist')(process.argv, { '--': true }).env || {});
-    } else if (typeof config === 'object' && typeof config.default === 'function') {
-        return config.default(require('minimist')(process.argv, { '--': true }).env || {});
-    } else {
-        return config;
-    }
+    return getConfig(configPath);
 }

--- a/src/loadConfigurationFile.js
+++ b/src/loadConfigurationFile.js
@@ -60,5 +60,18 @@ module.exports = function(configPath) {
             throw new Error('Could not load required module loading for ' + chalk.underline(configPath));
         }
     }
-    return require(configPath);
+    var config = require(configPath);
+    if (typeof config === 'function')
+        return config(
+            process.argv.filter(function (arg) {
+                return arg.slice(0, 6) === '--env.';
+            }).map(function (arg) {
+                var parts = arg.split('=');
+                return [parts[0].slice(6), parts.slice(1).join('=')];
+            }).reduce(function (env, pair) {
+                env[pair[0]] = pair[1];
+                return env;
+            }, {})
+        );
+    return config;
 }

--- a/src/loadConfigurationFile.js
+++ b/src/loadConfigurationFile.js
@@ -62,6 +62,6 @@ module.exports = function(configPath) {
     }
     var config = require(configPath);
     if (typeof config === 'function')
-        return config(require('minimist')(process.argv, { '--': true }).env);
+        return config(require('minimist')(process.argv, { '--': true }).env || {});
     return config;
 }

--- a/src/loadConfigurationFile.js
+++ b/src/loadConfigurationFile.js
@@ -63,5 +63,9 @@ module.exports = function(configPath) {
     var config = require(configPath);
     if (typeof config === 'function')
         return config(require('minimist')(process.argv, { '--': true }).env || {});
-    return config;
+    } else if (typeof config === 'object' && typeof config.default === 'function') {
+        return config.default(require('minimist')(process.argv, { '--': true }).env || {});
+    } else {
+        return config;
+    }
 }

--- a/src/loadConfigurationFile.js
+++ b/src/loadConfigurationFile.js
@@ -62,16 +62,6 @@ module.exports = function(configPath) {
     }
     var config = require(configPath);
     if (typeof config === 'function')
-        return config(
-            process.argv.filter(function (arg) {
-                return arg.slice(0, 6) === '--env.';
-            }).map(function (arg) {
-                var parts = arg.split('=');
-                return [parts[0].slice(6), parts.slice(1).join('=')];
-            }).reduce(function (env, pair) {
-                env[pair[0]] = pair[1];
-                return env;
-            }, {})
-        );
+        return config(require('minimist')(process.argv, { '--': true }).env);
     return config;
 }


### PR DESCRIPTION
https://github.com/trivago/parallel-webpack/pull/35

based on the changes suggested in that PR but apparently not further evaluated, this change should do what is required, even without all the steps in between mentioned here https://github.com/trivago/parallel-webpack/pull/35/files/bbdc8ffa14a2aa81adcdf5e1b5a5f1b951ffd215#r108773189

process.argv is in several locations overwritten by the args passed to the initial run.js and therefore always contain the required args so we just need to filter them, adjust them to kv pairs and then reduce them to an object to be passed as the env object