### PR TITLE
watch mode done callback

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ var workerFarm = require('worker-farm'),
     assign = require('lodash.assign'),
     pluralize = require('pluralize'),
     schema = require('./schema.json'),
-	loadConfigurationFile = require('./src/loadConfigurationFile').default,
-	startWatchIPCServer = require('./src/watchModeIPC').startWatchIPCServer;
+    loadConfigurationFile = require('./src/loadConfigurationFile').default,
+    startWatchIPCServer = require('./src/watchModeIPC').startWatchIPCServer;
 
 var ajv = new Ajv({
     allErrors: true,
@@ -23,17 +23,17 @@ function notSilent(options) {
 function startFarm(config, configPath, options, runWorker, callback) {
     config = Array.isArray(config) ? config : [config];
     options = options || {};
-	
-	// When in watch mode and a callback is provided start IPC server to invoke callback 
-	// once all webpack configurations have been compiled
-	if (options.watch) {
-		startWatchIPCServer(callback, Object.keys(config));
-	}
+
+    // When in watch mode and a callback is provided start IPC server to invoke callback
+    // once all webpack configurations have been compiled
+    if (options.watch) {
+        startWatchIPCServer(callback, Object.keys(config));
+    }
 
     if(notSilent(options)) {
         console.log(chalk.blue('[WEBPACK]') + ' Building ' + chalk.yellow(config.length) + ' ' + pluralize('target', config.length));
     }
-	
+
     var builds = config.map(function (c, i) {
         return runWorker(configPath, options, i, config.length);
     });
@@ -122,7 +122,7 @@ function run(configPath, options, callback) {
         configPath,
         options,
         Promise.promisify(workers),
-		callback
+        callback
     ).error(function(err) {
         if(notSilent(options)) {
             console.log('%s Build failed after %s seconds', chalk.red('[WEBPACK]'), chalk.blue((Date.now() - startTime) / 1000));
@@ -141,12 +141,12 @@ function run(configPath, options, callback) {
     }).finally(function () {
         workerFarm.end(workers);
         process.removeListener('SIGINT', shutdownCallback);
-	});
+    });
 
-	if (!options.watch) {
-		farmPromise.asCallback(callback);
-	}
-	return farmPromise;
+    if (!options.watch) {
+        farmPromise.asCallback(callback);
+    }
+    return farmPromise;
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ var workerFarm = require('worker-farm'),
     assign = require('lodash.assign'),
     pluralize = require('pluralize'),
     schema = require('./schema.json'),
-    loadConfigurationFile = require('./src/loadConfigurationFile').default;
+	loadConfigurationFile = require('./src/loadConfigurationFile').default,
+	startWatchIPCServer = require('./src/watchModeIPC').startWatchIPCServer;
 
 var ajv = new Ajv({
     allErrors: true,
@@ -19,13 +20,20 @@ function notSilent(options) {
     return !options.json;
 }
 
-function startFarm(config, configPath, options, runWorker) {
+function startFarm(config, configPath, options, runWorker, callback) {
     config = Array.isArray(config) ? config : [config];
     options = options || {};
+	
+	// When in watch mode and a callback is provided start IPC server to invoke callback 
+	// once all webpack configurations have been compiled
+	if (options.watch) {
+		startWatchIPCServer(callback, Object.keys(config));
+	}
 
     if(notSilent(options)) {
         console.log(chalk.blue('[WEBPACK]') + ' Building ' + chalk.yellow(config.length) + ' ' + pluralize('target', config.length));
     }
+	
     var builds = config.map(function (c, i) {
         return runWorker(configPath, options, i, config.length);
     });
@@ -109,11 +117,12 @@ function run(configPath, options, callback) {
     process.on('SIGINT', shutdownCallback);
 
     var startTime = Date.now();
-    return startFarm(
+    var farmPromise = startFarm(
         config,
         configPath,
         options,
-        Promise.promisify(workers)
+        Promise.promisify(workers),
+		callback
     ).error(function(err) {
         if(notSilent(options)) {
             console.log('%s Build failed after %s seconds', chalk.red('[WEBPACK]'), chalk.blue((Date.now() - startTime) / 1000));
@@ -132,7 +141,12 @@ function run(configPath, options, callback) {
     }).finally(function () {
         workerFarm.end(workers);
         process.removeListener('SIGINT', shutdownCallback);
-    }).asCallback(callback);
+	});
+
+	if (!options.watch) {
+		farmPromise.asCallback(callback);
+	}
+	return farmPromise;
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lodash.endswith": "^4.0.1",
     "lodash.flatten": "^4.2.0",
     "minimist": "^1.2.0",
+    "node-ipc": "^9.1.0",
     "pluralize": "^1.2.1",
     "supports-color": "^3.1.2",
     "worker-farm": "^1.3.1"

--- a/src/__tests__/watchDoneHandler.spec.js
+++ b/src/__tests__/watchDoneHandler.spec.js
@@ -3,39 +3,39 @@ let ipc;
 
 describe('watchDoneHandler', () => {
     beforeEach(() => {
-		watchDoneHandler = require('../watchDoneHandler');
-		ipc = {
-			server: {
-				stop: jest.fn()
-			}
-		}
+        watchDoneHandler = require('../watchDoneHandler');
+        ipc = {
+            server: {
+                stop: jest.fn()
+            }
+        }
     });
-	
-	 describe('watchDoneHandler', () => {
-		it('should remove index 1 from config', () => {
-			let configIndices = [0, 1];
-			let callback = jest.fn();
-			watchDoneHandler(null, null, configIndices, 1);
-			expect(configIndices).toEqual([0]);
-		});
 
-		it('should stop server and invoke callback', () => {
-			let configIndices = [0, 1];
-			let callback = jest.fn();
-			watchDoneHandler(callback, ipc, configIndices, 0);
-			watchDoneHandler(callback, ipc, configIndices, 1);
-			expect(configIndices).toEqual([]);
-			expect(callback).toHaveBeenCalled();
-			expect(ipc.server.stop).toHaveBeenCalled();
-		});
+     describe('watchDoneHandler', () => {
+        it('should remove index 1 from config', () => {
+            let configIndices = [0, 1];
+            let callback = jest.fn();
+            watchDoneHandler(null, null, configIndices, 1);
+            expect(configIndices).toEqual([0]);
+        });
 
-		it('should stop server', () => {
-			let configIndices = [0, 1];
-			let callback = jest.fn();
-			watchDoneHandler(null, ipc, configIndices, 0);
-			watchDoneHandler(null, ipc, configIndices, 1);
-			expect(configIndices).toEqual([]);
-			expect(ipc.server.stop).toHaveBeenCalled();
-		});
+        it('should stop server and invoke callback', () => {
+            let configIndices = [0, 1];
+            let callback = jest.fn();
+            watchDoneHandler(callback, ipc, configIndices, 0);
+            watchDoneHandler(callback, ipc, configIndices, 1);
+            expect(configIndices).toEqual([]);
+            expect(callback).toHaveBeenCalled();
+            expect(ipc.server.stop).toHaveBeenCalled();
+        });
+
+        it('should stop server', () => {
+            let configIndices = [0, 1];
+            let callback = jest.fn();
+            watchDoneHandler(null, ipc, configIndices, 0);
+            watchDoneHandler(null, ipc, configIndices, 1);
+            expect(configIndices).toEqual([]);
+            expect(ipc.server.stop).toHaveBeenCalled();
+        });
     });
 });

--- a/src/__tests__/watchDoneHandler.spec.js
+++ b/src/__tests__/watchDoneHandler.spec.js
@@ -1,0 +1,41 @@
+let watchDoneHandler;
+let ipc;
+
+describe('watchDoneHandler', () => {
+    beforeEach(() => {
+		watchDoneHandler = require('../watchDoneHandler');
+		ipc = {
+			server: {
+				stop: jest.fn()
+			}
+		}
+    });
+	
+	 describe('watchDoneHandler', () => {
+		it('should remove index 1 from config', () => {
+			let configIndices = [0, 1];
+			let callback = jest.fn();
+			watchDoneHandler(null, null, configIndices, 1);
+			expect(configIndices).toEqual([0]);
+		});
+
+		it('should stop server and invoke callback', () => {
+			let configIndices = [0, 1];
+			let callback = jest.fn();
+			watchDoneHandler(callback, ipc, configIndices, 0);
+			watchDoneHandler(callback, ipc, configIndices, 1);
+			expect(configIndices).toEqual([]);
+			expect(callback).toHaveBeenCalled();
+			expect(ipc.server.stop).toHaveBeenCalled();
+		});
+
+		it('should stop server', () => {
+			let configIndices = [0, 1];
+			let callback = jest.fn();
+			watchDoneHandler(null, ipc, configIndices, 0);
+			watchDoneHandler(null, ipc, configIndices, 1);
+			expect(configIndices).toEqual([]);
+			expect(ipc.server.stop).toHaveBeenCalled();
+		});
+    });
+});

--- a/src/__tests__/watchModeIPC.spec.js
+++ b/src/__tests__/watchModeIPC.spec.js
@@ -5,40 +5,40 @@ jest.mock('node-ipc');
 
 describe('watchModeIPC', () => {
     beforeEach(() => {
-		webpackWorker = require('../watchModeIPC.js');
-		nodeIpc = require('node-ipc');
-		nodeIpc.server = {
-			start: jest.fn()
-		};
-		nodeIpc.of = {
-			webpack: {
-				emit: jest.fn()
-			}
-		};
-		
-		nodeIpc.connectTo = function(serverName, onConnect) {
-			onConnect();
-		}
+        webpackWorker = require('../watchModeIPC.js');
+        nodeIpc = require('node-ipc');
+        nodeIpc.server = {
+            start: jest.fn()
+        };
+        nodeIpc.of = {
+            webpack: {
+                emit: jest.fn()
+            }
+        };
+
+        nodeIpc.connectTo = function(serverName, onConnect) {
+            onConnect();
+        }
     });
 
     describe('startWatchIPCServer', () => {
-		it('should start ipc socket server', () => {
-			webpackWorker.startWatchIPCServer();
-			expect(nodeIpc.config.id).toEqual('webpack');
-			expect(nodeIpc.config.retry).toEqual(3);
-			expect(nodeIpc.config.silent).toEqual(true);
-			expect(nodeIpc.serve).toHaveBeenCalled();
-			expect(nodeIpc.server.start).toHaveBeenCalled();
-		});
-	});
-	
-	 describe('notifyIPCWatchCompileDone', () => {
-		it('should call connectTo', () => {
-			webpackWorker.notifyIPCWatchCompileDone(0);
-			expect(nodeIpc.config.id).toEqual('webpack0');
-			expect(nodeIpc.config.stopRetrying).toEqual(3);
-			expect(nodeIpc.config.silent).toEqual(true);
-			expect(nodeIpc.of.webpack.emit).toHaveBeenCalledWith('done', 0);
-		})
+        it('should start ipc socket server', () => {
+            webpackWorker.startWatchIPCServer();
+            expect(nodeIpc.config.id).toEqual('webpack');
+            expect(nodeIpc.config.retry).toEqual(3);
+            expect(nodeIpc.config.silent).toEqual(true);
+            expect(nodeIpc.serve).toHaveBeenCalled();
+            expect(nodeIpc.server.start).toHaveBeenCalled();
+        });
+    });
+
+     describe('notifyIPCWatchCompileDone', () => {
+        it('should call connectTo', () => {
+            webpackWorker.notifyIPCWatchCompileDone(0);
+            expect(nodeIpc.config.id).toEqual('webpack0');
+            expect(nodeIpc.config.stopRetrying).toEqual(3);
+            expect(nodeIpc.config.silent).toEqual(true);
+            expect(nodeIpc.of.webpack.emit).toHaveBeenCalledWith('done', 0);
+        })
     });
 });

--- a/src/__tests__/watchModeIPC.spec.js
+++ b/src/__tests__/watchModeIPC.spec.js
@@ -1,0 +1,44 @@
+let webpackWorker;
+let nodeIpc;
+let serveSpy;
+jest.mock('node-ipc');
+
+describe('watchModeIPC', () => {
+    beforeEach(() => {
+		webpackWorker = require('../watchModeIPC.js');
+		nodeIpc = require('node-ipc');
+		nodeIpc.server = {
+			start: jest.fn()
+		};
+		nodeIpc.of = {
+			webpack: {
+				emit: jest.fn()
+			}
+		};
+		
+		nodeIpc.connectTo = function(serverName, onConnect) {
+			onConnect();
+		}
+    });
+
+    describe('startWatchIPCServer', () => {
+		it('should start ipc socket server', () => {
+			webpackWorker.startWatchIPCServer();
+			expect(nodeIpc.config.id).toEqual('webpack');
+			expect(nodeIpc.config.retry).toEqual(3);
+			expect(nodeIpc.config.silent).toEqual(true);
+			expect(nodeIpc.serve).toHaveBeenCalled();
+			expect(nodeIpc.server.start).toHaveBeenCalled();
+		});
+	});
+	
+	 describe('notifyIPCWatchCompileDone', () => {
+		it('should call connectTo', () => {
+			webpackWorker.notifyIPCWatchCompileDone(0);
+			expect(nodeIpc.config.id).toEqual('webpack0');
+			expect(nodeIpc.config.stopRetrying).toEqual(3);
+			expect(nodeIpc.config.silent).toEqual(true);
+			expect(nodeIpc.of.webpack.emit).toHaveBeenCalledWith('done', 0);
+		})
+    });
+});

--- a/src/__tests__/webpackWorker.spec.js
+++ b/src/__tests__/webpackWorker.spec.js
@@ -3,16 +3,19 @@ const close = jest.fn();
 const watch = jest.fn().mockReturnValue({ close });
 
 jest.setMock('webpack',  () => ({ run, watch })); // try to get rid of this.
+jest.mock('../watchModeIPC');
 
 let webpackWorker;
 let promiseMock;
 let webpackMock;
+let notifyIPCWatchCompileDone; 
 
 describe('webpackWorker', () => {
     beforeEach(() => {
         promiseMock = require('bluebird');
         webpackMock = require('webpack');
         webpackWorker = require('../webpackWorker.js');
+        notifyIPCWatchCompileDone = require('../watchModeIPC').notifyIPCWatchCompileDone;
         jest.doMock('testConfig', () => ({ webpack: 'config' }), { virtual: true });
         jest.resetModules();
         jest.clearAllMocks();
@@ -133,6 +136,7 @@ describe('webpackWorker', () => {
                 expect(process.listenerCount('SIGINT')).toBe(1);
                 expect(doneCallback).not.toHaveBeenCalled();
                 expect(console.log.mock.calls).toMatchSnapshot();
+                expect(notifyIPCWatchCompileDone).toHaveBeenCalledWith(0);
                 process.removeAllListeners('SIGINT');
                 jest.useRealTimers();
                 global.Date = _temp;

--- a/src/__tests__/webpackWorker.spec.js
+++ b/src/__tests__/webpackWorker.spec.js
@@ -8,7 +8,7 @@ jest.mock('../watchModeIPC');
 let webpackWorker;
 let promiseMock;
 let webpackMock;
-let notifyIPCWatchCompileDone; 
+let notifyIPCWatchCompileDone;
 
 describe('webpackWorker', () => {
     beforeEach(() => {

--- a/src/watchDoneHandler.js
+++ b/src/watchDoneHandler.js
@@ -1,0 +1,15 @@
+/**
+ * Handler for done event
+ * @param data - the configuration index of the completed webpack run
+ */
+module.exports = function watchDoneHandler(callback, ipc, configIndices, data) {
+	// Once every configuration has completed once, stop the server and invoke the callback
+	configIndices.splice(configIndices.indexOf(data), 1);
+	if (!configIndices.length) {
+		ipc.server.stop();
+
+		if (typeof callback === 'function') {
+			callback();
+		}
+	}
+};

--- a/src/watchDoneHandler.js
+++ b/src/watchDoneHandler.js
@@ -3,13 +3,13 @@
  * @param data - the configuration index of the completed webpack run
  */
 module.exports = function watchDoneHandler(callback, ipc, configIndices, data) {
-	// Once every configuration has completed once, stop the server and invoke the callback
-	configIndices.splice(configIndices.indexOf(data), 1);
-	if (!configIndices.length) {
-		ipc.server.stop();
+    // Once every configuration has completed once, stop the server and invoke the callback
+    configIndices.splice(configIndices.indexOf(data), 1);
+    if (!configIndices.length) {
+        ipc.server.stop();
 
-		if (typeof callback === 'function') {
-			callback();
-		}
-	}
+        if (typeof callback === 'function') {
+            callback();
+        }
+    }
 };

--- a/src/watchModeIPC.js
+++ b/src/watchModeIPC.js
@@ -1,0 +1,44 @@
+var ipc = require('node-ipc'),
+	serverName = 'webpack',
+	watchDoneHandler = require('./watchDoneHandler');
+
+module.exports = {
+
+	/**
+	 * Start IPC server and listens for 'done' message from child processes
+	 * @param {any} callback - callback invoked once 'done' has been emitted by each confugration 
+	 * @param {any} configIndices - array indices of configuration
+	 */
+	startWatchIPCServer: function startWatchIPCServer(callback, configIndices) {
+		ipc.config.id = serverName;
+		ipc.config.retry = 3;
+		ipc.config.silent = true;
+
+		ipc.serve(
+			function() {
+				ipc.server.on(
+					'done',
+					watchDoneHandler.bind(this, callback, ipc, configIndices)
+				);
+			}
+		);
+		ipc.server.start();
+	},
+
+	/* 
+	* Notifies parent process that a complete compile has occured in watch mode
+	* @param {any} index 
+	*/
+	notifyIPCWatchCompileDone: function notifyIPCWatchCompileDone(index) {
+		ipc.config.id = serverName + index;
+		ipc.config.stopRetrying = 3;
+		ipc.config.silent = true;
+
+		ipc.connectTo(
+			serverName,
+			function() {
+				ipc.of.webpack.emit('done', index);
+			}
+		);
+	}	
+}

--- a/src/watchModeIPC.js
+++ b/src/watchModeIPC.js
@@ -1,44 +1,44 @@
 var ipc = require('node-ipc'),
-	serverName = 'webpack',
-	watchDoneHandler = require('./watchDoneHandler');
+    serverName = 'webpack',
+    watchDoneHandler = require('./watchDoneHandler');
 
 module.exports = {
 
-	/**
-	 * Start IPC server and listens for 'done' message from child processes
-	 * @param {any} callback - callback invoked once 'done' has been emitted by each confugration 
-	 * @param {any} configIndices - array indices of configuration
-	 */
-	startWatchIPCServer: function startWatchIPCServer(callback, configIndices) {
-		ipc.config.id = serverName;
-		ipc.config.retry = 3;
-		ipc.config.silent = true;
+    /**
+     * Start IPC server and listens for 'done' message from child processes
+     * @param {any} callback - callback invoked once 'done' has been emitted by each confugration
+     * @param {any} configIndices - array indices of configuration
+     */
+    startWatchIPCServer: function startWatchIPCServer(callback, configIndices) {
+        ipc.config.id = serverName;
+        ipc.config.retry = 3;
+        ipc.config.silent = true;
 
-		ipc.serve(
-			function() {
-				ipc.server.on(
-					'done',
-					watchDoneHandler.bind(this, callback, ipc, configIndices)
-				);
-			}
-		);
-		ipc.server.start();
-	},
+        ipc.serve(
+            function() {
+                ipc.server.on(
+                    'done',
+                    watchDoneHandler.bind(this, callback, ipc, configIndices)
+                );
+            }
+        );
+        ipc.server.start();
+    },
 
-	/* 
-	* Notifies parent process that a complete compile has occured in watch mode
-	* @param {any} index 
-	*/
-	notifyIPCWatchCompileDone: function notifyIPCWatchCompileDone(index) {
-		ipc.config.id = serverName + index;
-		ipc.config.stopRetrying = 3;
-		ipc.config.silent = true;
+    /*
+    * Notifies parent process that a complete compile has occured in watch mode
+    * @param {any} index
+    */
+    notifyIPCWatchCompileDone: function notifyIPCWatchCompileDone(index) {
+        ipc.config.id = serverName + index;
+        ipc.config.stopRetrying = 3;
+        ipc.config.silent = true;
 
-		ipc.connectTo(
-			serverName,
-			function() {
-				ipc.of.webpack.emit('done', index);
-			}
-		);
-	}	
+        ipc.connectTo(
+            serverName,
+            function() {
+                ipc.of.webpack.emit('done', index);
+            }
+        );
+    }
 }


### PR DESCRIPTION
Adds callback for watch mode that is called once every configuration has been compiled once.

- Main process starts an [ipc](https://github.com/RIAEvangelist/node-ipc) server that listens for the worker processes to emit 'done'.
- Worker processes wait for finishedCallback and then notify the ipc server they are complete and the callback is invoked.

