### PR TITLE
Update package.json to support webpack 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/trivago/parallel-webpack/issues"
   },
   "peerDependencies": {
-    "webpack": "^1.12.9 || ^2.2.0 || ^3.0.0"
+    "webpack": "^1.12.9 || ^2.2.0 || ^3.x"
   },
   "dependencies": {
     "ajv": "^4.9.2",


### PR DESCRIPTION
It is not possible to run `npm install parallel-webpack` using the latest webpack@3.1.0.

`-- UNMET PEER DEPENDENCY webpack@3.1.0`