### PR TITLE
Incomplete replacement fix

### DIFF
--- a/src/__tests__/webpackWorker.spec.js
+++ b/src/__tests__/webpackWorker.spec.js
@@ -224,6 +224,20 @@ describe('webpackWorker', () => {
                     'bundle.testApp.js'
                 );
             });
+
+            it('should replace all matches of "[name]" pattern if there is one entry point', () => {
+                getAppNameTest(
+                    {
+                        output: {
+                            filename: 'bundle/[name]/[name].js',
+                        },
+                        entry: {
+                            testApp: 'filepath',
+                        }
+                    },
+                    'bundle/testApp/testApp.js'
+                );
+            });
         });
 
         describe('getOutputOptions', () => {

--- a/src/webpackWorker.js
+++ b/src/webpackWorker.js
@@ -21,7 +21,7 @@ function getAppName(webpackConfig) {
         var entryNames = Object.keys(webpackConfig.entry);
         if(entryNames.length === 1) {
             // we can only replace [name] with the entry point if there is only one entry point
-            appName = appName.replace(/\[name]/, entryNames[0]);
+            appName = appName.replace(/\[name]/g, entryNames[0]);
         }
     }
     return appName;


### PR DESCRIPTION
In case of several matches of "[name]" only the first one was replaced, though sometimes the expression is used several times in a template.