### PR TITLE
update lodash.endswith require

### DIFF
--- a/src/loadConfigurationFile.js
+++ b/src/loadConfigurationFile.js
@@ -1,5 +1,5 @@
 var jsVars = require('interpret').jsVariants,
-    endsWith = require('lodash').endsWith,
+    endsWith = require('lodash.endswith'),
     availableExts = Object.keys(jsVars),
     chalk = require('chalk');
 


### PR DESCRIPTION
Update `lodash.endswith` require stmt because having:
```
TypeError: endsWith is not a function
    at getMatchingLoaderFn (/home/sites/oleg.andreyev/src/opcart/node_modules/parallel-webpack/src/loadConfigurationFile.js:30:12)
    at default (/home/sites/oleg.andreyev/src/opcart/node_modules/parallel-webpack/src/loadConfigurationFile.js:51:19)
    at module.exports (/home/sites/oleg.andreyev/src/opcart/node_modules/parallel-webpack/src/webpackWorker.js:67:18)
    at handle (/home/sites/oleg.andreyev/src/opcart/node_modules/worker-farm/lib/child/index.js:44:8)
    at process.<anonymous> (/home/sites/oleg.andreyev/src/opcart/node_modules/worker-farm/lib/child/index.js:51:3)
    at emitTwo (events.js:106:13)
    at process.emit (events.js:191:7)
    at process.nextTick (internal/child_process.js:744:12)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

Usage Ref.: https://www.npmjs.com/package/lodash.endswith