### PR TITLE
Callback for every webpack build in watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,30 @@ function notify() {
 
 run(configPath, options, notify);
 ```
+
+You can pass a notify callback for every webpack watch callback as well.
+```javascript
+var run = require('parallel-webpack').run,
+    configPath = require.resolve('./webpack.config.js'),
+    options = {/*...*/};
+
+let qeueu = [];
+run(configPath, options, () => {
+    console.log('[webpack-parallel] every configuration has been compiled. I will not be invoked anymore');
+}, (list, i) => {
+    if (qeueu.length === 0) {
+        qeueu = list.map(Number);
+    }
+    console.log(`[webpack-parallel] configuration #${i} is compiled in watch mode.`);
+    if (qeueu.includes(i)) {
+        qeueu.splice(qeueu.indexOf(i), 1);
+        if (qeueu.length === 0) {
+            console.log(`[webpack-parallel] all configurations(${list.join(',')}) were compiled in watch mode.`);
+        }
+    }
+});
+```
+
 **NOTE:** In watch mode notify callback provided with Node.js API will run **only once**
 when all of the builds are finished.
 

--- a/src/watchDoneHandler.js
+++ b/src/watchDoneHandler.js
@@ -2,11 +2,13 @@
  * Handler for done event
  * @param data - the configuration index of the completed webpack run
  */
-module.exports = function watchDoneHandler(callback, ipc, configIndices, data) {
+module.exports = function watchDoneHandler(callback, ipc, configIndices, dontStop, data) {
     // Once every configuration has completed once, stop the server and invoke the callback
     configIndices.splice(configIndices.indexOf(data), 1);
     if (!configIndices.length) {
-        ipc.server.stop();
+        if (!dontStop) {
+            ipc.server.stop();
+        }
 
         if (typeof callback === 'function') {
             callback();

--- a/src/watchModeIPC.js
+++ b/src/watchModeIPC.js
@@ -7,21 +7,31 @@ module.exports = {
     /**
      * Start IPC server and listens for 'done' message from child processes
      * @param {any} callback - callback invoked once 'done' has been emitted by each confugration
+     * @param {Function} watchCallback - callback invoked on every webpack compile in watch mode
      * @param {any} configIndices - array indices of configuration
      */
-    startWatchIPCServer: function startWatchIPCServer(callback, configIndices) {
+    startWatchIPCServer: function startWatchIPCServer(callback, watchCallback, configIndices) {
         ipc.config.id = serverName;
         ipc.config.retry = 3;
         ipc.config.silent = true;
+
+        var dontStopServer = !!watchCallback;
 
         ipc.serve(
             function() {
                 ipc.server.on(
                     'done',
-                    watchDoneHandler.bind(this, callback, ipc, configIndices)
+                    watchDoneHandler.bind(this, callback, ipc, configIndices, dontStopServer)
                 );
+                if (watchCallback) {
+                    ipc.server.on(
+                        'watchCallback',
+                        watchCallback.bind(null, [].concat(configIndices))
+                    )
+                }
             }
         );
+
         ipc.server.start();
     },
 
@@ -40,5 +50,18 @@ module.exports = {
                 ipc.of.webpack.emit('done', index);
             }
         );
-    }
+    },
+
+    notifyIPCWatchCallback: function notifyIPCWatchCallback(index) {
+        ipc.config.id = serverName + index;
+        ipc.config.stopRetrying = 3;
+        ipc.config.silent = true;
+
+        ipc.connectTo(
+            serverName,
+            function() {
+                ipc.of.webpack.emit('watchCallback', index);
+            }
+        );
+    },
 }

--- a/src/webpackWorker.js
+++ b/src/webpackWorker.js
@@ -2,6 +2,7 @@ var Promise = require('bluebird'),
     chalk = require('chalk'),
     loadConfigurationFile = require('./loadConfigurationFile').default,
     notifyIPCWatchCompileDone = require('./watchModeIPC').notifyIPCWatchCompileDone,
+    notifyIPCWatchCallback = require('./watchModeIPC').notifyIPCWatchCallback,
     presetToOptions = require('webpack/lib/Stats').presetToOptions;
 /**
  * Choose the most correct version of webpack, prefer locally installed version,
@@ -135,10 +136,14 @@ module.exports = function(configuratorFileName, options, index, expectedConfigLe
                 if(!watch) {
                     process.removeListener('SIGINT', shutdownCallback);
                     done(null, options.stats ? JSON.stringify(stats.toJson(outputOptions), null, 2) : '');
-                } else if (!hasCompletedOneCompile) {
-                    notifyIPCWatchCompileDone(index);
-                    hasCompletedOneCompile = true;
+                } else {
+                    notifyIPCWatchCallback(index);
+                    if (!hasCompletedOneCompile) {
+                        notifyIPCWatchCompileDone(index);
+                        hasCompletedOneCompile = true;
+                    }
                 }
+
             };
         if(!silent) {
             console.log('%s Started %s %s', chalk.blue('[WEBPACK]'), watch ? 'watching' : 'building', chalk.yellow(getAppName(webpackConfig)));


### PR DESCRIPTION
It's very useful to detect every compiler done event to trigger third party routines.
Only for 2.x branch.