### PR TITLE
Handle config function return promise of config object array

### DIFF
--- a/__tests__/__snapshots__/index.spec.js.snap
+++ b/__tests__/__snapshots__/index.spec.js.snap
@@ -3,9 +3,6 @@
 exports[`index.js run error callback should log and reject with error 1`] = `
 Array [
   Array [
-    "[34m[WEBPACK][39m Building [33m1[39m target",
-  ],
-  Array [
     "%s Build failed after %s seconds",
     "[31m[WEBPACK][39m",
     "[34m0.3[39m",
@@ -28,9 +25,6 @@ Property: "options.maxConcurrentWorkers" should be number],
 exports[`index.js run shutdownCallback should call end  and remove callback 1`] = `
 Array [
   Array [
-    "[34m[WEBPACK][39m Building [33m1[39m target",
-  ],
-  Array [
     "[31m[WEBPACK][39m Forcefully shutting down",
   ],
 ]
@@ -38,9 +32,6 @@ Array [
 
 exports[`index.js run then callback should filter non-truthy and return results 1`] = `
 Array [
-  Array [
-    "[34m[WEBPACK][39m Building [33m1[39m target",
-  ],
   Array [
     "%s Finished build after %s seconds",
     "[34m[WEBPACK][39m",

--- a/src/__tests__/findConfigFile.spec.js
+++ b/src/__tests__/findConfigFile.spec.js
@@ -1,12 +1,14 @@
 jest.mock('fs');
 
-import findConfigFile from '../findConfigFile';
 import fs from 'fs';
+
+import findConfigFile from '../findConfigFile';
 
 const possibleExtensions = [
     '',
     '.js',
     '.babel.js',
+    '.babel.ts',
     '.buble.js',
     '.cirru',
     '.cjsx',
@@ -14,6 +16,7 @@ const possibleExtensions = [
     '.coffee',
     '.coffee.md',
     '.eg',
+    '.esm.js',
     '.iced',
     '.iced.md',
     '.jsx',
@@ -21,6 +24,7 @@ const possibleExtensions = [
     '.liticed',
     '.ls',
     '.ts',
+    '.tsx',
     '.wisp'
 ];
 
@@ -53,7 +57,7 @@ describe('findConfigFile', () => {
             findConfigFile('/path/to/file')
         }).toThrow();
 
-        expect(fs.statSync).toHaveBeenCalledTimes(18);
+        expect(fs.statSync).toHaveBeenCalledTimes(possibleExtensions.length);
     });
 
     it('should return file from accessSync', () => {

--- a/src/__tests__/loadConfigurationFile.spec.js
+++ b/src/__tests__/loadConfigurationFile.spec.js
@@ -16,6 +16,8 @@ describe('loadConfigurationFile module', () => {
     it('should sort the extensions', () => {
         let unsortedVariants = Object.keys(jsVariants);
         let sortedVariants = [
+            '.babel.js',
+            '.babel.ts',
             '.buble.js',
             '.coffee.md',
             '.babel.js',
@@ -32,6 +34,7 @@ describe('loadConfigurationFile module', () => {
             '.liticed',
             '.ls',
             '.ts',
+            '.tsx',
             '.eg'];
         // based on the test, we only care if the array is sorted based on the compare function
         // the result of the sort function seems to be different on node 6 and 11 but the expected

--- a/src/webpackWorker.js
+++ b/src/webpackWorker.js
@@ -70,24 +70,28 @@ module.exports = function(configuratorFileName, options, index, expectedConfigLe
         process.argv = options.argv;
     }
     chalk.enabled = options.colors;
-    var config = loadConfigurationFile(configuratorFileName),
-        watch = !!options.watch,
-        silent = !!options.json;
-    if(expectedConfigLength !== 1 && !Array.isArray(config)
-            || Array.isArray(config) && config.length !== expectedConfigLength) {
-        if(config.length !== expectedConfigLength) {
-            var errorMessage = '[WEBPACK] There is a difference between the amount of the'
-                + ' provided configs. Maybe you where expecting command line'
-                + ' arguments to be passed to your webpack.config.js. If so,'
-                + " you'll need to separate them with a -- from the parallel-webpack options.";
-            console.error(errorMessage);
-            return Promise.reject(errorMessage);
+    var config = loadConfigurationFile(configuratorFileName)
+
+    Promise.resolve(config).then(function(config) {
+        var watch = !!options.watch,
+            silent = !!options.json;
+        if(expectedConfigLength !== 1 && !Array.isArray(config)
+                || (Array.isArray(config) && config.length !== expectedConfigLength)) {
+            if(config.length !== expectedConfigLength) {
+                var errorMessage = '[WEBPACK] There is a difference between the amount of the'
+                    + ' provided configs. Maybe you where expecting command line'
+                    + ' arguments to be passed to your webpack.config.js. If so,'
+                    + " you'll need to separate them with a -- from the parallel-webpack options.";
+                console.error(errorMessage);
+                throw Error(errorMessage);
+            }
         }
-    }
-    if(Array.isArray(config)) {
-        config = config[index];
-    }
-    Promise.resolve(config).then(function(webpackConfig) {
+        var webpackConfig;
+        if(Array.isArray(config)) {
+            webpackConfig = config[index];
+        } else {
+            webpackConfig = config
+        }
         var watcher,
             webpack = getWebpack(),
             hasCompletedOneCompile = false,


### PR DESCRIPTION
For #76 .
I've changed a little how `startFarm` and `webpackWorker` get config and added a test for config function return promise of config object array.
After the change, there are some tests get failed. And I'm not sure how to handle them. @pago @efegurkan I need some advices about them:

**webpackWorker.spec.js**

* webpackWorker › arguments › multi config options › should fail if expectedConfigLength > 1 in case of single config
* webpackWorker › arguments › multi config options › should fail if expectedConfigLength dont match with config.length

This two all expect `Promise.reject` will be called when call `webpackWorker` function. Before this change they will be called immediately. But since we have to get the config array after promise resolved,
I move the config length checking part into the `then` part, so they will not be called immediately and we cannot check the mock synchronously. I have tried checking calls asynchronously in test (`webpackWorker.then(...)`) but it seems that `webpackWorker` will not finish until jest test time out.

**index.spec.js**

* index.js › run › error callback › should log and reject with error
* index.js › run › then callback › should filter non-truthy and return results
* index.js › run › shutdownCallback › should call end  and remove callback

The above three snapshot tests will lose one line `"[WEBPACK] Building 1 target"` since we have to move the `console.log` into promise(again now we have to resolve config function promise before we know its length). Not sure if it's ok to pass those snapshot tests. 