### PR TITLE
chore: fix typo

### DIFF
--- a/src/__tests__/webpackWorker.spec.js
+++ b/src/__tests__/webpackWorker.spec.js
@@ -150,7 +150,7 @@ describe('webpackWorker', () => {
 
         describe('multi config options', () => {
             const multiConfigTest = options => {
-                const errorMessage = '[WEBPACK] There is a difference between the amount of the provided configs. Maybe you where expecting command line arguments to be passed to your webpack.config.js. If so, you\'ll need to separate them with a -- from the parallel-webpack options.'
+                const errorMessage = '[WEBPACK] There is a difference between the amount of the provided configs. Maybe you were expecting command line arguments to be passed to your webpack.config.js. If so, you\'ll need to separate them with a -- from the parallel-webpack options.'
                 jest.doMock('multiTestConfig', () => ( [{ fail: true}, { webpack: 'config'}]), { virtual: true });
                 jest.spyOn(console, 'error').mockImplementation(() => {});
 

--- a/src/webpackWorker.js
+++ b/src/webpackWorker.js
@@ -77,7 +77,7 @@ module.exports = function(configuratorFileName, options, index, expectedConfigLe
             || Array.isArray(config) && config.length !== expectedConfigLength) {
         if(config.length !== expectedConfigLength) {
             var errorMessage = '[WEBPACK] There is a difference between the amount of the'
-                + ' provided configs. Maybe you where expecting command line'
+                + ' provided configs. Maybe you were expecting command line'
                 + ' arguments to be passed to your webpack.config.js. If so,'
                 + " you'll need to separate them with a -- from the parallel-webpack options.";
             console.error(errorMessage);


### PR DESCRIPTION
Fixes the typo from #74 , but also updates the snapshot (done manually, because jest didn't seem to parse the updateSnapshot argument =/ ).