### PR TITLE
Prevent async writes from being terminated before being written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+# master
+- Switch from `process.exit()` to `process.exitCode` to prevent cutting off async writes
+
 ## [v2.3.0](https://github.com/trivago/parallel-webpack/tree/v2.3.0) (2018-02-26)
 [Full Changelog](https://github.com/trivago/parallel-webpack/compare/v2.2.0...v2.3.0)
 

--- a/bin/run.js
+++ b/bin/run.js
@@ -56,7 +56,7 @@ if(argv.version) {
             }
         }).catch(function(err) {
             console.log(err.message);
-            process.exit(1);
+            process.exitCode = 1;
         });
     } catch (e) {
         if(e.message) {
@@ -65,6 +65,6 @@ if(argv.version) {
         } else {
             process.stdout.write(chalk.red('[WEBPACK]') + ' Could not load configuration ' + chalk.underline(process.cwd() + '/' + argv.config) + "\n");
         }
-        process.exit(1);
+        process.exitCode = 1;
     }
 }

--- a/src/webpackWorker.js
+++ b/src/webpackWorker.js
@@ -99,7 +99,7 @@ module.exports = function(configuratorFileName, options, index, expectedConfigLe
                 done({
                     message: chalk.red('[WEBPACK]') + ' Forcefully shut down ' + chalk.yellow(getAppName(webpackConfig))
                 });
-                process.exit(0);
+                process.exitCode = 0;
             },
             finishedCallback = function(err, stats) {
                 if(err) {


### PR DESCRIPTION
Might fix #85. Haven't tested it yet. TODO.