### PR TITLE
Include webpack 5 as peer dependence

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/trivago/parallel-webpack/issues"
   },
   "peerDependencies": {
-    "webpack": "^1.12.9 || ^2.2.0 || ^3.x || ^4.x"
+    "webpack": "^1.12.9 || ^2.2.0 || ^3.x || ^4.x || ^5.x"
   },
   "dependencies": {
     "ajv": "^4.9.2",


### PR DESCRIPTION
Because of error while npm install project with webpack5

> npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! Found: webpack@5.24.4
npm ERR! node_modules/webpack
npm ERR!   dev webpack@"^5.24.4" from the root project
npm ERR!   peer webpack@">=4.6.0" from @loadable/webpack-plugin@5.14.2
npm ERR!   node_modules/@loadable/webpack-plugin
npm ERR!     dev @loadable/webpack-plugin@"^5.14.2" from the root project
npm ERR!   15 more (@webpack-cli/configtest, babel-loader, ...)
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer webpack@"^1.12.9 || ^2.2.0 || ^3.x || ^4.x" from parallel-webpack@2.6.0
npm ERR! node_modules/parallel-webpack
npm ERR!   dev parallel-webpack@"^2.6.0" from the root project